### PR TITLE
Add inline editor and import controls to savings activity

### DIFF
--- a/savings-activity.html
+++ b/savings-activity.html
@@ -48,8 +48,22 @@
     </div>
 
     <div class="toolbar">
-      <label class="btn linklike" for="csvInput">Import CSV</label>
-      <input id="csvInput" type="file" accept=".csv" style="display:none"/>
+      <button id="importBtn" class="btn">Import CSV</button>
+      <input type="file" id="csvFile" accept=".csv" hidden />
+      <button class="btn" id="addTxnBtn">Add Transaction</button>
+        <form id="inlineEditor" style="display:none;gap:8px;align-items:center;">
+            <input type="hidden" id="eIndex" value="-1" />
+            <input type="date" id="eDate" required />
+            <select id="eStatus">
+            <option>Posted</option>
+            <option>Processing</option>
+            <option>Pending</option>
+            </select>
+            <input type="text" id="eDesc" placeholder="Description" required />
+            <input type="number" step="0.01" id="eAmount" placeholder="-12.34, +34.10" required />
+            <button type="submit" class="btn">Save</button>
+            <button type="button" class="btn ghost" id="cancelEditBtn">Cancel</button>
+        </form>
       <input id="search" class="input" placeholder="Search description..."/>
       <select id="statusSelect" class="input">
         <option value="all">All statuses</option>
@@ -63,9 +77,9 @@
     </div>
 
     <div class="table-wrap">
-      <table>
+      <table id="activityTable">
         <thead><tr><th>Date</th><th>Description</th><th>Status</th><th class="amount">Amount</th></tr></thead>
-        <tbody id="tbody"></tbody>
+        <tbody></tbody>
       </table>
     </div>
 


### PR DESCRIPTION
## Summary
- Replace CSV label/input with Import CSV button and hidden file input
- Add Add Transaction button and inline editor like other activity pages
- Give savings activity table an explicit `id="activityTable"`

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b797159d9c832689fa7a2a3a269b6f