### PR TITLE
Load Chart.js for debit activity

### DIFF
--- a/debit-activity.html
+++ b/debit-activity.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <title>Discover — Debit Activity</title>
   <link rel="stylesheet" href="styles.css"/>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.3/dist/chart.umd.min.js"></script>
 </head>
 <body data-account="debit" data-csv="data/debit.csv">
   <header class="topbar">


### PR DESCRIPTION
## Summary
- load Chart.js via CDN before other scripts on debit activity page

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68b799ef95f08326ae70d4c5ae97b02e