### PR TITLE
Align debit and savings charts with credit layout

### DIFF
--- a/debit-activity.html
+++ b/debit-activity.html
@@ -5,7 +5,10 @@
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <title>Discover — Debit Activity</title>
   <link rel="stylesheet" href="styles.css"/>
-  <script src="assets/chart.umd.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.3/dist/chart.umd.min.js"></script>
+  <style>
+    .trend-card{background:linear-gradient(#e9edf4,#ffffff);border:1px solid #dfe6f3;border-radius:16px;padding:16px}
+  </style>
 </head>
 <body data-account="debit" data-csv="data/debit.csv">
   <header class="topbar">
@@ -40,8 +43,8 @@
       <div class="carousel-track">
         <div class="carousel-item">
             <div class="small-title">Spending trend</div>
-            <canvas id="trendChart" style="width:100%;height:140px;border:1px solid var(--divider);border-radius:12px"></canvas>
-            </div>
+            <div class="trend-card"><canvas id="trendChart" height="120"></canvas></div>
+        </div>
         <div class="carousel-item"><div class="small-title">Money In vs Out</div><div style="height:120px;border:1px solid var(--divider);border-radius:12px"></div></div>
         <div class="carousel-item"><div class="small-title">Categories</div><div style="height:120px;border:1px solid var(--divider);border-radius:12px"></div></div>
       </div>

--- a/savings-activity.html
+++ b/savings-activity.html
@@ -7,7 +7,10 @@
   <link rel="stylesheet" href="styles.css"/>
 
   <!-- Chart.js for spending trend -->
-  <script src="assets/chart.umd.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.3/dist/chart.umd.min.js"></script>
+  <style>
+    .trend-card{background:linear-gradient(#e9edf4,#ffffff);border:1px solid #dfe6f3;border-radius:16px;padding:16px}
+  </style>
 </head>
 <body data-account="savings" data-csv="data/savings.csv">
   <header class="topbar">
@@ -42,8 +45,8 @@
       <div class="carousel-track">
         <div class="carousel-item">
             <div class="small-title">Spending trend</div>
-            <canvas id="trendChart" style="width:100%;height:140px;border:1px solid var(--divider);border-radius:12px"></canvas>
-            </div>
+            <div class="trend-card"><canvas id="trendChart" height="120"></canvas></div>
+        </div>
         <div class="carousel-item"><div class="small-title">Money In vs Out</div><div style="height:120px;border:1px solid var(--divider);border-radius:12px"></div></div>
         <div class="carousel-item"><div class="small-title">Categories</div><div style="height:120px;border:1px solid var(--divider);border-radius:12px"></div></div>
       </div>


### PR DESCRIPTION
## Summary
- Load Chart.js from CDN on debit and savings activity pages and add matching trend card styling.
- Wrap debit and savings spending trend canvases in styled cards and set fixed height for chart container.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b79602f55083268aa77a99d999bfed