### PR TITLE
Add debit activity summary card with balance

### DIFF
--- a/activity.js
+++ b/activity.js
@@ -17,6 +17,7 @@
     const table = $("#activityTable");
     const tbody = $("#activityTable tbody");
     const trendCanvas = $("#trendChart");
+    const balanceEl = $("#accountBalance");
 
     // Optional toolbar buttons you may already have
     const importBtn = $("#importBtn");
@@ -229,6 +230,12 @@
 
       // trend
       buildTrendChart(rows);
+
+      // account balance display
+      if (balanceEl) {
+        const total = rows.reduce((sum, r) => sum + (Number(r.amount) || 0), 0);
+        balanceEl.textContent = fmtUSD(total);
+      }
     }
 
     // ---- CSV helpers ----

--- a/debit-activity.html
+++ b/debit-activity.html
@@ -7,6 +7,9 @@
   <link rel="stylesheet" href="styles.css"/>
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.3/dist/chart.umd.min.js"></script>
   <style>
+    .row{display:grid;gap:18px}
+    @media(min-width:900px){.row{grid-template-columns:1fr 1fr}}
+    .row-card{background:#fff;border:1px solid #e5ebf7;border-radius:16px;padding:18px;box-shadow:var(--shadow)}
     .trend-card{background:linear-gradient(#e9edf4,#ffffff);border:1px solid #dfe6f3;border-radius:16px;padding:16px}
   </style>
 </head>
@@ -37,6 +40,21 @@
 
   <main class="container">
     <h1 class="hero-greet">Cashback Debit — Activity</h1>
+
+    <section class="row" aria-label="Account summary">
+      <div class="row-card">
+        <div style="display:flex;align-items:center;justify-content:space-between;gap:1rem">
+          <div>
+            <span class="pill">Acct •••• 5195</span>
+            <h2 style="margin:10px 0 0">Cashback Debit</h2>
+          </div>
+          <div style="text-align:right">
+            <div class="label">Available Balance</div>
+            <div id="accountBalance" style="font-weight:900;font-size:28px">$0.00</div>
+          </div>
+        </div>
+      </div>
+    </section>
 
     <div id="chart-wrap" class="carousel">
       <div class="pills-row"><span class="mini-pill">This Month</span></div>


### PR DESCRIPTION
## Summary
- Add account summary card to debit activity page with available balance display
- Compute and show balance from CSV in activity script for consistency across pages

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b7a8d4c500832690d78cbb9a682b84