### PR TITLE
Add editable balance card to debit activity page

### DIFF
--- a/activity.js
+++ b/activity.js
@@ -17,6 +17,8 @@
     const table = $("#activityTable");
     const tbody = $("#activityTable tbody");
     const trendCanvas = $("#trendChart");
+    const balanceEl = $("#accountBalance");
+    const balanceInput = $("#balanceInput");
 
     // Optional toolbar buttons you may already have
     const importBtn = $("#importBtn");
@@ -229,6 +231,14 @@
 
       // trend
       buildTrendChart(rows);
+
+      // account balance display
+      const total = rows.reduce((sum, r) => sum + (Number(r.amount) || 0), 0);
+      if (balanceInput) {
+        balanceInput.value = total.toFixed(2);
+      } else if (balanceEl) {
+        balanceEl.textContent = fmtUSD(total);
+      }
     }
 
     // ---- CSV helpers ----

--- a/debit-activity.html
+++ b/debit-activity.html
@@ -7,7 +7,21 @@
   <link rel="stylesheet" href="styles.css"/>
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.3/dist/chart.umd.min.js"></script>
   <style>
+    .row{display:grid;gap:18px}
+    @media(min-width:900px){.row{grid-template-columns:1fr 1fr}}
+    .row-card{background:#fff;border:1px solid #e5ebf7;border-radius:16px;padding:18px;box-shadow:var(--shadow)}
     .trend-card{background:linear-gradient(#e9edf4,#ffffff);border:1px solid #dfe6f3;border-radius:16px;padding:16px}
+    .balance-edit{display:flex;align-items:center;gap:.5rem;justify-content:flex-end}
+    .balance-input{
+      width:150px;max-width:45vw;
+      font:900 28px/1 var(--font,ui-sans-serif,system-ui);
+      color:#0e213e;text-align:right;
+      border:1px solid #dfe6f3;border-radius:10px;padding:.25rem .5rem;
+      background:#f7f9fd;
+    }
+    .balance-input::-webkit-outer-spin-button,
+    .balance-input::-webkit-inner-spin-button{ -webkit-appearance:none; margin:0 }
+    .balance-help{font-size:12px;color:#5a6d89;margin-top:4px;text-align:right}
   </style>
 </head>
 <body data-account="debit" data-csv="data/debit.csv">
@@ -37,6 +51,25 @@
 
   <main class="container">
     <h1 class="hero-greet">Cashback Debit — Activity</h1>
+
+    <section class="row" aria-label="Account summary">
+      <div class="row-card">
+        <div style="display:flex;align-items:center;justify-content:space-between;gap:1rem">
+          <div>
+            <span class="pill">Acct •••• 5195</span>
+            <h2 style="margin:10px 0 0">Cashback Debit</h2>
+          </div>
+          <div style="min-width:260px">
+            <div class="label" style="text-align:right">Available Balance</div>
+            <div class="balance-edit">
+              <span style="font-weight:900;font-size:28px">$</span>
+              <input id="balanceInput" class="balance-input" type="number" step="0.01" inputmode="decimal" aria-label="Available balance amount" value="0.00"/>
+            </div>
+            <div class="balance-help">Tip: type a value and press Enter</div>
+          </div>
+        </div>
+      </div>
+    </section>
 
     <div id="chart-wrap" class="carousel">
       <div class="pills-row"><span class="mini-pill">This Month</span></div>
@@ -263,6 +296,17 @@
   <!-- === /Footer === -->
 
   <script src="activity.js"></script>
+  <script>
+    const balanceInput = document.getElementById('balanceInput');
+    if (balanceInput) {
+      balanceInput.addEventListener('change', (e) => {
+        e.target.value = Number(e.target.value || 0).toFixed(2);
+      });
+      balanceInput.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter') e.target.blur();
+      });
+    }
+  </script>
   <script src="app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Add editable balance input and helper text to debit activity summary card
- Style and script balance editor for consistent credit-style layout
- Populate balance input from CSV totals via activity script

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7a8d4c500832690d78cbb9a682b84