### PR TITLE
Add account summary card to savings activity page

### DIFF
--- a/savings-activity.html
+++ b/savings-activity.html
@@ -9,6 +9,9 @@
   <!-- Chart.js for spending trend -->
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.3/dist/chart.umd.min.js"></script>
   <style>
+    .row{display:grid;gap:18px}
+    @media(min-width:900px){.row{grid-template-columns:1fr 1fr}}
+    .row-card{background:#fff;border:1px solid #e5ebf7;border-radius:16px;padding:18px;box-shadow:var(--shadow)}
     .trend-card{background:linear-gradient(#e9edf4,#ffffff);border:1px solid #dfe6f3;border-radius:16px;padding:16px}
   </style>
 </head>
@@ -39,6 +42,21 @@
 
   <main class="container">
     <h1 class="hero-greet">Online Savings — Activity</h1>
+
+    <section class="row" aria-label="Account summary">
+      <div class="row-card">
+        <div style="display:flex;align-items:center;justify-content:space-between;gap:1rem">
+          <div>
+            <span class="pill">Acct •••• 1067</span>
+            <h2 style="margin:10px 0 0">Online Savings</h2>
+          </div>
+          <div style="text-align:right">
+            <div class="label">Available Balance</div>
+            <div id="accountBalance" style="font-weight:900;font-size:28px">$0.00</div>
+          </div>
+        </div>
+      </div>
+    </section>
 
     <div id="chart-wrap" class="carousel">
       <div class="pills-row"><span class="mini-pill">This Month</span></div>


### PR DESCRIPTION
## Summary
- Add account summary card to Online Savings activity page displaying account number and dynamic balance
- Include shared row and row-card styles for layout consistency

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npx eslint savings-activity.html` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68b7bee899548326915bbcd750577eab