### PR TITLE
Expand transfer page account options

### DIFF
--- a/transfer.html
+++ b/transfer.html
@@ -45,10 +45,19 @@
       <select id="from" class="input">
         <option value="debit">Cashback Debit (5195)</option>
         <option value="savings">Online Savings (1067)</option>
+        <option value="wells">Wells Fargo Checking (•••• 4774)</option>
+        <option value="chime">Chime Checking (•••• 2874)</option>
+        <option value="discover">Discover Debit (•••• 4920)</option>
       </select>
 
-      <label>To account</label>
-      <div class="input readonly">Wells Fargo Checking (•••• 1234)</div>
+      <label for="to">To account</label>
+      <select id="to" class="input">
+        <option value="debit">Cashback Debit (5195)</option>
+        <option value="savings">Online Savings (1067)</option>
+        <option value="wells">Wells Fargo Checking (•••• 4774)</option>
+        <option value="chime">Chime Checking (•••• 2874)</option>
+        <option value="discover">Discover Debit (•••• 4920)</option>
+      </select>
 
       <label for="amount">Amount</label>
       <input id="amount" class="input" type="number" min="0" step="0.01" placeholder="0.00"/>


### PR DESCRIPTION
## Summary
- Add Wells Fargo, Chime, and Discover Debit transfer options with masked digits
- Enable selecting any account on both sides of the transfer form

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68b8fde6fc588326945f1bfb5a2e722c